### PR TITLE
[Fixes] Snap store build fail

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,10 +100,11 @@ parts:
   pappl-retrofit:
     source: https://github.com/openprinting/pappl-retrofit
     source-type: git
-    source-tag: '1.0b2'
+    # source-tag: '1.0b2'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
+#     ignore: true
 #     format: '%V'
     plugin: autotools
     autotools-configure-parameters:
@@ -277,6 +278,7 @@ parts:
       export SNAPCRAFT_PROJECT_VERSION="$version"
     build-packages:
       - jq
+      - curl
     stage-packages:
       - libpaper1
       - libfontconfig1


### PR DESCRIPTION
- commented pappl-retrofit source tag so that it can use git master instead of last release
- added 'curl' in build packages